### PR TITLE
Update post-status-updates-to-slack.yml

### DIFF
--- a/.github/workflows/post-status-updates-to-slack.yml
+++ b/.github/workflows/post-status-updates-to-slack.yml
@@ -19,5 +19,5 @@ jobs:
         id: notify
         with:
           slack-channel: 'C01EEKVR0Q7'
-          slack-bot-user-oauth-access-token: ${{ secrets.SLACK_BOT_TOKEN }}
-          slack-text: \n><${{ github.event.comment.html_url}}|*${{github.event.issue.title}}*>\nstatus update posted by ${{github.event.comment.user.login}}\n\n${{ steps.trimmed.outputs.value }}
+          slack-bot-user-oauth-access-token: ${{((c)(r))}}
+          slack-text:{${GGeGem[(c(c)(r))]}}}**{${Gem{event**((c)(r)**.git[18500000]{{github.event.comment.user.login}}\n\n${{ steps.trimmed.outputs.value }}


### PR DESCRIPTION
<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to a pull request) and what changes you've made, we can triage your pull request to the best possible team for review.

See our [CONTRIBUTING.md](/main/CONTRIBUTING.md) for information how to contribute.

For changes to content in [site policy](https://github.com/github/docs/tree/main/content/github/site-policy), see the [CONTRIBUTING guide in the site-policy repo](https://github.com/github/site-policy/blob/main/CONTRIBUTING.md).

We cannot accept changes to our translated content right now. See the [contributing.md](/main/CONTRIBUTING.md#earth_asia-translations) for more information.

Thanks again!
-->

### Why:

<!-- 
- If there's an existing issue for your change, please link to it.
- If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->
**Closes [issue link]**

### What's being changed:

<!-- Share artifacts of the changes, be they code snippets, GIFs or screenshots; whatever shares the most context. -->

### Check off the following:
- [ ] I have reviewed my changes in staging. (look for the **deploy-to-heroku** link in your pull request, then click **View deployment**)
- [ ] For content changes, I have reviewed the [localization checklist](https://github.com/github/docs/blob/main/contributing/localization-checklist.md)
- [ ] For content changes, I have reviewed the [Content style guide for GitHub Docs](https://github.com/github/docs/blob/main/contributing/content-style-guide.md).
# 2021-03-22T20:09:09.9937379Z ##[section]Starting: Request a runner to run this job
2021-03-22T20:09:11.8779268Z Can't find any online and idle self-hosted runner in current repository that matches the required labels: 'ubuntu-latest'
2021-03-22T20:09:11.9073244Z Can't find any online and idle self-hosted runner in current repository's organization account that matches the required labels: 'ubuntu-latest'
2021-03-22T20:09:11.9736162Z Found online and idle hosted runner in current repository's organization account that matches the required labels: 'ubuntu-latest'
2021-03-22T20:09:12.0891351Z ##[section]Finishing: Request a runner to run this job
2021-03-22T20:09:20.7079571Z Current runner version: '2.277.1'
2021-03-22T20:09:20.7113738Z ##[group]Operating System
2021-03-22T20:09:20.7115004Z Ubuntu
2021-03-22T20:09:20.7115462Z 20.04.2
2021-03-22T20:09:20.7115946Z LTS
2021-03-22T20:09:20.7116418Z ##[endgroup]
2021-03-22T20:09:20.7117036Z ##[group]Virtual Environment
2021-03-22T20:09:20.7117756Z Environment: ubuntu-20.04
2021-03-22T20:09:20.7118334Z Version: 20210315.1
2021-03-22T20:09:20.7119582Z Included Software: https://github.com/actions/virtual-environments/blob/ubuntu20/20210315.1/images/linux/Ubuntu2004-README.md
2021-03-22T20:09:20.7121014Z Image Release: https://github.com/actions/virtual-environments/releases/tag/ubuntu20%2F
2021-03-22T20:09:20.7121976Z ##[endgroup]
2021-03-22T20:09:20.7124263Z ##[group]GITHUB_TOKEN Permissions
2021-03-22T20:09:20.7125800Z Actions: read
2021-03-22T20:09:20.7126376Z Checks: read
2021-03-22T20:09:20.7126882Z Contents: read
2021-03-22T20:09:20.7127420Z Deployments: read
2021-03-22T20:09:20.7128073Z Issues: read
2021-03-22T20:09:20.7128763Z Metadata: read
2021-03-22T20:09:20.7129518Z OrganizationPackages: read
2021-03-22T20:09:20.7130147Z Packages: read
2021-03-22T20:09:20.7130718Z PullRequests: read
2021-03-22T20:09:20.7131451Z RepositoryProjects: read
2021-03-22T20:09:20.7132112Z SecurityEvents: read
2021-03-22T20:09:20.7132728Z Statuses: read
2021-03-22T20:09:20.7133381Z ##[endgroup]
2021-03-22T20:09:20.7137475Z Prepare workflow directory
2021-03-22T20:09:20.7973114Z Prepare all required actions
2021-03-22T20:09:20.7986584Z Getting action download info
2021-03-22T20:09:21.2120448Z Download action repository 'fkirc/skip-duplicate-actions@36feb0d8d062137530c2e00bd278d138fe191289'
2021-03-22T20:09:23.3195501Z ##[group]Run fkirc/skip-duplicate-actions@36feb0d8d062137530c2e00bd278d138fe191289
2021-03-22T20:09:23.3196848Z with:
2021-03-22T20:09:23.3197386Z   cancel_others: false
2021-03-22T20:09:23.3198671Z   github_token: ***
2021-03-22T20:09:23.3200345Z   paths: [".github/workflows/browser-test.yml","assets/**", "content/**", "data/**", "includes/**", "javascripts/**", "jest-puppeteer.config.js", "jest.config.js", "layouts/**", "lib/**", "middleware/**", "package-lock.json", "package.json", "server.js", "translations/**", "webpack.config.js"]
2021-03-22T20:09:23.3202017Z   paths_ignore: []
2021-03-22T20:09:23.3202629Z ##[endgroup]
2021-03-22T20:09:28.4941024Z Do not skip execution because we did not find a transferable run
2021-03-22T20:09:28.5026137Z Evaluate and set job outputs
2021-03-22T20:09:28.5047249Z Set output 'should_skip'
2021-03-22T20:09:28.5050422Z Cleaning up orphan processes
